### PR TITLE
 feat: research ERC721 and ERC1155 compatibility for unified contract implementation

### DIFF
--- a/Scaffold/packages/snfoundry/contracts/Scarb.lock
+++ b/Scaffold/packages/snfoundry/contracts/Scarb.lock
@@ -6,6 +6,7 @@ name = "contracts"
 version = "0.2.0"
 dependencies = [
  "openzeppelin_access",
+ "openzeppelin_account",
  "openzeppelin_introspection",
  "openzeppelin_token",
  "openzeppelin_utils",

--- a/Scaffold/packages/snfoundry/contracts/Scarb.toml
+++ b/Scaffold/packages/snfoundry/contracts/Scarb.toml
@@ -9,6 +9,7 @@ edition = "2023_11"
 starknet = "2.9.2"
 # Change to just "openzeppelin" to use full features
 openzeppelin_access = "0.20.0"
+openzeppelin_account = "0.20.0"
 openzeppelin_token = "0.20.0"
 openzeppelin_introspection = "0.20.0"
 

--- a/Scaffold/packages/snfoundry/contracts/src/interface/erc1155.cairo
+++ b/Scaffold/packages/snfoundry/contracts/src/interface/erc1155.cairo
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.17.0 (token/erc1155/interface.cairo)
+
+use starknet::ContractAddress;
+
+pub const IERC1155_ID: felt252 = 0x6114a8f75559e1b39fcba08ce02961a1aa082d9256a158dd3e64964e4b1b52;
+pub const IERC1155_METADATA_URI_ID: felt252 =
+    0xcabe2400d5fe509e1735ba9bad205ba5f3ca6e062da406f72f113feb889ef7;
+pub const IERC1155_RECEIVER_ID: felt252 =
+    0x15e8665b5af20040c3af1670509df02eb916375cdf7d8cbaf7bd553a257515e;
+
+#[starknet::interface]
+pub trait IERC1155<TState> {
+    fn balance_of(self: @TState, account: ContractAddress, token_id: u256) -> u256;
+    fn balance_of_batch(
+        self: @TState, accounts: Span<ContractAddress>, token_ids: Span<u256>
+    ) -> Span<u256>;
+    fn safe_transfer_from(
+        ref self: TState,
+        from: ContractAddress,
+        to: ContractAddress,
+        token_id: u256,
+        value: u256,
+        data: Span<felt252>
+    );
+    fn safe_batch_transfer_from(
+        ref self: TState,
+        from: ContractAddress,
+        to: ContractAddress,
+        token_ids: Span<u256>,
+        values: Span<u256>,
+        data: Span<felt252>
+    );
+    fn is_approved_for_all(
+        self: @TState, owner: ContractAddress, operator: ContractAddress
+    ) -> bool;
+    fn set_approval_for_all(ref self: TState, operator: ContractAddress, approved: bool);
+}
+
+#[starknet::interface]
+pub trait IERC1155MetadataURI<TState> {
+    fn uri(self: @TState, token_id: u256) -> ByteArray;
+}
+
+#[starknet::interface]
+pub trait IERC1155Camel<TState> {
+    fn balanceOf(self: @TState, account: ContractAddress, tokenId: u256) -> u256;
+    fn balanceOfBatch(
+        self: @TState, accounts: Span<ContractAddress>, tokenIds: Span<u256>
+    ) -> Span<u256>;
+    fn safeTransferFrom(
+        ref self: TState,
+        from: ContractAddress,
+        to: ContractAddress,
+        tokenId: u256,
+        value: u256,
+        data: Span<felt252>
+    );
+    fn safeBatchTransferFrom(
+        ref self: TState,
+        from: ContractAddress,
+        to: ContractAddress,
+        tokenIds: Span<u256>,
+        values: Span<u256>,
+        data: Span<felt252>
+    );
+    fn isApprovedForAll(self: @TState, owner: ContractAddress, operator: ContractAddress) -> bool;
+    fn setApprovalForAll(ref self: TState, operator: ContractAddress, approved: bool);
+}
+
+//
+// ERC1155 ABI
+//
+
+#[starknet::interface]
+pub trait ERC1155ABI<TState> {
+    // IERC1155
+    fn balance_of(self: @TState, account: ContractAddress, token_id: u256) -> u256;
+    fn balance_of_batch(
+        self: @TState, accounts: Span<ContractAddress>, token_ids: Span<u256>
+    ) -> Span<u256>;
+    fn safe_transfer_from(
+        ref self: TState,
+        from: ContractAddress,
+        to: ContractAddress,
+        token_id: u256,
+        value: u256,
+        data: Span<felt252>
+    );
+    fn safe_batch_transfer_from(
+        ref self: TState,
+        from: ContractAddress,
+        to: ContractAddress,
+        token_ids: Span<u256>,
+        values: Span<u256>,
+        data: Span<felt252>
+    );
+    fn is_approved_for_all(
+        self: @TState, owner: ContractAddress, operator: ContractAddress
+    ) -> bool;
+    fn set_approval_for_all(ref self: TState, operator: ContractAddress, approved: bool);
+
+    // ISRC5
+    fn supports_interface(self: @TState, interface_id: felt252) -> bool;
+
+    // IERC1155MetadataURI
+    fn uri(self: @TState, token_id: u256) -> ByteArray;
+
+    // IERC1155Camel
+    fn balanceOf(self: @TState, account: ContractAddress, tokenId: u256) -> u256;
+    fn balanceOfBatch(
+        self: @TState, accounts: Span<ContractAddress>, tokenIds: Span<u256>
+    ) -> Span<u256>;
+    fn safeTransferFrom(
+        ref self: TState,
+        from: ContractAddress,
+        to: ContractAddress,
+        tokenId: u256,
+        value: u256,
+        data: Span<felt252>
+    );
+    fn safeBatchTransferFrom(
+        ref self: TState,
+        from: ContractAddress,
+        to: ContractAddress,
+        tokenIds: Span<u256>,
+        values: Span<u256>,
+        data: Span<felt252>
+    );
+    fn isApprovedForAll(self: @TState, owner: ContractAddress, operator: ContractAddress) -> bool;
+    fn setApprovalForAll(ref self: TState, operator: ContractAddress, approved: bool);
+}
+
+//
+// IERC1155Receiver
+//
+
+#[starknet::interface]
+pub trait IERC1155Receiver<TState> {
+    fn on_erc1155_received(
+        self: @TState,
+        operator: ContractAddress,
+        from: ContractAddress,
+        token_id: u256,
+        value: u256,
+        data: Span<felt252>
+    ) -> felt252;
+    fn on_erc1155_batch_received(
+        self: @TState,
+        operator: ContractAddress,
+        from: ContractAddress,
+        token_ids: Span<u256>,
+        values: Span<u256>,
+        data: Span<felt252>
+    ) -> felt252;
+}
+
+#[starknet::interface]
+pub trait IERC1155ReceiverCamel<TState> {
+    fn onERC1155Received(
+        self: @TState,
+        operator: ContractAddress,
+        from: ContractAddress,
+        tokenId: u256,
+        value: u256,
+        data: Span<felt252>
+    ) -> felt252;
+    fn onERC1155BatchReceived(
+        self: @TState,
+        operator: ContractAddress,
+        from: ContractAddress,
+        tokenIds: Span<u256>,
+        values: Span<u256>,
+        data: Span<felt252>
+    ) -> felt252;
+}
+
+#[starknet::interface]
+pub trait ERC1155ReceiverABI<TState> {
+    // IERC1155Receiver
+    fn on_erc1155_received(
+        self: @TState,
+        operator: ContractAddress,
+        from: ContractAddress,
+        token_id: u256,
+        value: u256,
+        data: Span<felt252>
+    ) -> felt252;
+    fn on_erc1155_batch_received(
+        self: @TState,
+        operator: ContractAddress,
+        from: ContractAddress,
+        token_ids: Span<u256>,
+        values: Span<u256>,
+        data: Span<felt252>
+    ) -> felt252;
+
+    // IERC1155ReceiverCamel
+    fn onERC1155Received(
+        self: @TState,
+        operator: ContractAddress,
+        from: ContractAddress,
+        tokenId: u256,
+        value: u256,
+        data: Span<felt252>
+    ) -> felt252;
+    fn onERC1155BatchReceived(
+        self: @TState,
+        operator: ContractAddress,
+        from: ContractAddress,
+        tokenIds: Span<u256>,
+        values: Span<u256>,
+        data: Span<felt252>
+    ) -> felt252;
+
+    // ISRC5
+    fn supports_interface(self: @TState, interface_id: felt252) -> bool;
+}

--- a/Scaffold/packages/snfoundry/contracts/src/lib.cairo
+++ b/Scaffold/packages/snfoundry/contracts/src/lib.cairo
@@ -10,4 +10,5 @@ mod test {
 }
 mod mock_contracts {
     pub mod Receiver;
+    pub mod erc1155_erc721_research;
 }

--- a/Scaffold/packages/snfoundry/contracts/src/lib.cairo
+++ b/Scaffold/packages/snfoundry/contracts/src/lib.cairo
@@ -12,3 +12,7 @@ mod mock_contracts {
     pub mod Receiver;
     pub mod erc1155_erc721_research;
 }
+
+mod interface {
+    pub mod erc1155;
+}

--- a/Scaffold/packages/snfoundry/contracts/src/mock_contracts/erc1155_erc721_research.cairo
+++ b/Scaffold/packages/snfoundry/contracts/src/mock_contracts/erc1155_erc721_research.cairo
@@ -204,6 +204,7 @@ pub mod ERC1155_ERC721_Combined_token {
             owner
         }
 
+        ///     BOTH   ERC721 AND ERC1155
         /// Transfers ownership of `value` amount of `token_id` from `from` if `to` is either an
         /// account or `IERC1155Receiver`.
         ///
@@ -252,6 +253,7 @@ pub mod ERC1155_ERC721_Combined_token {
             }
         }
 
+        ///            ERC1155 ONLY
         /// Requirements:
         ///
         /// - Caller is either approved or the `token_id` owner.
@@ -284,6 +286,7 @@ pub mod ERC1155_ERC721_Combined_token {
             self.update_with_acceptance_check(from, to, token_ids, values, data);
         }
 
+        ///         ERC721 ONLY
         /// - Caller is either approved or the `token_id` owner.
         /// - `to` is not the zero address.
         /// - `from` is not the zero address.
@@ -304,6 +307,7 @@ pub mod ERC1155_ERC721_Combined_token {
             assert(from == previous_owner, Errors::INVALID_SENDER);
         }
 
+        ///            ERC721 ONLY
         /// Returns the address approved for `token_id`.
         ///
         /// Requirements:
@@ -315,6 +319,7 @@ pub mod ERC1155_ERC721_Combined_token {
             self.ERC721_token_approvals.read(token_id)
         }
 
+        ///            ERC1155 ONLY
         /// Queries if `operator` is an authorized operator for `owner`.
         #[external(v0)]
         fn is_approved_for_all(
@@ -328,7 +333,7 @@ pub mod ERC1155_ERC721_Combined_token {
         ///
         /// Requirements:
         /// 
-        /// - `token_type` must be 1 for erc1155 token or 2 for erc721
+        /// - `token_type` must be 1155 for erc1155 token or 721 for erc721
         ///
         /// - `operator` cannot be the caller.
         ///
@@ -360,18 +365,21 @@ pub mod ERC1155_ERC721_Combined_token {
     #[abi(per_item)]
     #[generate_trait]
     pub impl TokenMetadataImpl of TokenMetadataTrait {
+        ///            ERC721 ONLY
         /// Returns the NFT name.
         #[external(v0)]
         fn name(self: @ContractState) -> ByteArray {
             self.ERC721_name.read()
         }
 
+        ///            ERC721 ONLY
         /// Returns the NFT symbol.
         #[external(v0)]
         fn symbol(self: @ContractState) -> ByteArray {
             self.ERC721_symbol.read()
         }
 
+        ///            ERC721 ONLY
         /// Returns the Uniform Resource Identifier (URI) for the `token_id` token.
         /// If the URI is not set, the return value will be an empty ByteArray.
         ///
@@ -389,6 +397,7 @@ pub mod ERC1155_ERC721_Combined_token {
             }
         }
 
+        ///            ERC1155 ONLY
         /// This implementation returns the same URI for *all* token types. It relies
         /// on the token type ID substitution mechanism defined in the EIP:
         /// https://eips.ethereum.org/EIPS/eip-1155#metadata.
@@ -407,8 +416,8 @@ pub mod ERC1155_ERC721_Combined_token {
         /// This should only be used inside the contract's constructor.
         /// @notice One can pass args based on the needed token, empty string `""` can be passed for
         /// params @notice token_type can only be 1155 or 721, pass 0 to initialize both
-        /// ERC1155 and ERC721 tokens @param token_type Determines the token to initialize, 1
-        /// initializes ERC1155 token, 2 initializes ERC721 token, 0 initializes both.
+        /// ERC1155 and ERC721 tokens @param token_type Determines the token to initialize,
+        /// 1155 initializes ERC1155 token, 721 initializes ERC721 token, 0 initializes both.
         fn initializer(
             ref self: ContractState,
             name: ByteArray,
@@ -439,6 +448,7 @@ pub mod ERC1155_ERC721_Combined_token {
             }
         }
 
+        ///            ERC721 ONLY
         /// Transfers `token_id` from `from` to `to`.
         ///
         /// Internal function without access restriction.
@@ -464,7 +474,9 @@ pub mod ERC1155_ERC721_Combined_token {
             assert(from == previous_owner, Errors::INVALID_SENDER);
         }
 
-        /// Transfers ownership of `token_id` from `from` if `to` is either an account or
+        ///            ERC721 ONLY
+        ///             
+        ///  Transfers ownership of `token_id` from `from` if `to` is either an account or
         /// `IERC721Receiver`.
         ///
         /// `data` is additional data, it has no specified format and it is sent in call to `to`.
@@ -493,18 +505,20 @@ pub mod ERC1155_ERC721_Combined_token {
             );
         }
 
+        ///            ERC721 ONLY
         /// Returns whether `token_id` exists.
         fn exists(self: @ContractState, token_id: u256) -> bool {
             !self._owner_of(token_id).is_zero()
         }
 
+        ///            ERC721 ONLY
         fn _approve(
             ref self: ContractState, to: ContractAddress, token_id: u256, auth: ContractAddress,
         ) {
             self._approve_with_optional_event(to, token_id, auth, true);
         }
 
-        /// ERC721 only
+        ///                ERC721 ONLY
         /// Mints `token_id` and transfers it to `to`.
         /// Internal function without access restriction.
         ///
@@ -577,6 +591,7 @@ pub mod ERC1155_ERC721_Combined_token {
             self.token_types.write(token_id, 1155);
         }
 
+        ///         ERC1155 ONLY
         /// Batched version of `mint_with_acceptance_check`.
         ///
         /// Requirements:
@@ -607,6 +622,7 @@ pub mod ERC1155_ERC721_Combined_token {
             }
         }
 
+        ///         BOTH ERC1155 AND ERC721
         /// Destroys a `value` amount of tokens of type `token_id` from `from`.
         ///
         /// Requirements:
@@ -636,6 +652,7 @@ pub mod ERC1155_ERC721_Combined_token {
             }
         }
 
+        ///         ERC1155 ONLY
         /// Batched version of `burn`.
         ///
         /// Requirements:

--- a/Scaffold/packages/snfoundry/contracts/src/mock_contracts/erc1155_erc721_research.cairo
+++ b/Scaffold/packages/snfoundry/contracts/src/mock_contracts/erc1155_erc721_research.cairo
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+/// Combined ERC721 and ERC1155 Contract in Cairo 2.0
+/// @notice Research purpose, not meant for use
+
+#[starknet::contract]
+pub mod ERC1155_ERC721_Combined_token {
+    use core::num::traits::Zero;
+    use starknet::{ ContractAddress, get_caller_address };
+    use starknet::storage::{ Map, StorageMapReadAccess, StorageMapWriteAccess };
+    use openzeppelin::
+}

--- a/Scaffold/packages/snfoundry/contracts/src/mock_contracts/erc1155_erc721_research.cairo
+++ b/Scaffold/packages/snfoundry/contracts/src/mock_contracts/erc1155_erc721_research.cairo
@@ -5,7 +5,953 @@
 #[starknet::contract]
 pub mod ERC1155_ERC721_Combined_token {
     use core::num::traits::Zero;
-    use starknet::{ ContractAddress, get_caller_address };
-    use starknet::storage::{ Map, StorageMapReadAccess, StorageMapWriteAccess };
-    use openzeppelin::
+    use starknet::{ContractAddress, get_caller_address};
+    use starknet::storage::{
+        Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
+        StoragePointerWriteAccess,
+    };
+    use openzeppelin_token::erc721::interface;
+    use openzeppelin_token::erc721::interface::{
+        IERC721ReceiverDispatcher, IERC721ReceiverDispatcherTrait,
+    };
+    use openzeppelin_token::erc1155::interface::{
+        IERC1155ReceiverDispatcher, IERC1155ReceiverDispatcherTrait,
+    };
+    use contracts::interface::erc1155;
+    use openzeppelin_account::interface::ISRC6_ID;
+    use openzeppelin_introspection::src5::SRC5Component;
+    use openzeppelin_introspection::interface::{ISRC5Dispatcher, ISRC5DispatcherTrait};
+    use openzeppelin_token::erc1155::interface::{IERC1155Dispatcher, IERC1155DispatcherTrait};
+    use openzeppelin_token::erc721::interface::{IERC721Dispatcher, IERC721DispatcherTrait};
+
+    component!(path: SRC5Component, storage: src5, event: SRC5Event);
+    impl SRC5InternalImpl = SRC5Component::InternalImpl<ContractState>;
+
+    #[storage]
+    pub struct Storage {
+        /// ERC721 Storage
+        pub ERC721_name: ByteArray,
+        pub ERC721_symbol: ByteArray,
+        pub ERC721_owners: Map<u256, ContractAddress>,
+        pub ERC721_balances: Map<ContractAddress, u256>,
+        pub ERC721_token_approvals: Map<u256, ContractAddress>,
+        pub ERC721_operator_approvals: Map<(ContractAddress, ContractAddress), bool>,
+        pub ERC721_base_uri: ByteArray,
+        /// ERC1155 Storage
+        pub ERC1155_balances: Map<(u256, ContractAddress), u256>,
+        pub ERC1155_operator_approvals: Map<(ContractAddress, ContractAddress), bool>,
+        pub ERC1155_uri: ByteArray,
+        // 1 == ERC1155, 2 == ERC721
+        pub token_types: Map<u256, u8>,
+        #[substorage(v0)]
+        src5: SRC5Component::Storage,
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    pub enum Event {
+        // ERC721 Events
+        Transfer: Transfer,
+        Approval: Approval,
+        ApprovalForAll: ApprovalForAll,
+        // ERC1155 Events
+        TransferSingle: TransferSingle,
+        TransferBatch: TransferBatch,
+        URI: URI,
+        #[flat]
+        SRC5Event: SRC5Component::Event,
+    }
+
+    // ERC721 Events
+    #[derive(Drop, PartialEq, starknet::Event)]
+    pub struct Transfer {
+        #[key]
+        pub from: ContractAddress,
+        #[key]
+        pub to: ContractAddress,
+        #[key]
+        pub token_id: u256,
+    }
+
+    #[derive(Drop, PartialEq, starknet::Event)]
+    pub struct Approval {
+        #[key]
+        pub owner: ContractAddress,
+        #[key]
+        pub approved: ContractAddress,
+        #[key]
+        pub token_id: u256,
+    }
+
+    #[derive(Drop, PartialEq, starknet::Event)]
+    pub struct ApprovalForAll {
+        #[key]
+        pub owner: ContractAddress,
+        #[key]
+        pub operator: ContractAddress,
+        pub approved: bool,
+    }
+
+    // ERC1155 Events
+    #[derive(Drop, PartialEq, starknet::Event)]
+    pub struct TransferSingle {
+        #[key]
+        pub operator: ContractAddress,
+        #[key]
+        pub from: ContractAddress,
+        #[key]
+        pub to: ContractAddress,
+        pub id: u256,
+        pub value: u256,
+    }
+
+    #[derive(Drop, PartialEq, starknet::Event)]
+    pub struct TransferBatch {
+        #[key]
+        pub operator: ContractAddress,
+        #[key]
+        pub from: ContractAddress,
+        #[key]
+        pub to: ContractAddress,
+        pub ids: Span<u256>,
+        pub values: Span<u256>,
+    }
+
+    #[derive(Drop, PartialEq, starknet::Event)]
+    pub struct URI {
+        pub value: ByteArray,
+        #[key]
+        pub id: u256,
+    }
+
+    pub mod Errors {
+        pub const UNAUTHORIZED: felt252 = 'ERC1155: unauthorized operator';
+        pub const SELF_APPROVAL: felt252 = 'ERC1155: self approval';
+        pub const INVALID_RECEIVER: felt252 = 'ERC1155: invalid receiver';
+        pub const INVALID_SENDER: felt252 = 'ERC1155: invalid sender';
+        pub const INVALID_ARRAY_LENGTH: felt252 = 'ERC1155: no equal array length';
+        pub const INSUFFICIENT_BALANCE: felt252 = 'ERC1155: insufficient balance';
+        pub const SAFE_TRANSFER_FAILED: felt252 = 'ERC1155: safe transfer failed';
+
+        pub const INVALID_ACCOUNT: felt252 = 'ERC721: invalid account';
+        pub const INVALID_OPERATOR: felt252 = 'ERC721: invalid operator';
+        pub const INVALID_TOKEN_ID: felt252 = 'ERC721: invalid token ID';
+        pub const ALREADY_MINTED: felt252 = 'ERC721: token already minted';
+        pub const SAFE_MINT_FAILED: felt252 = 'ERC721: safe mint failed';
+        pub const INVALID_TOKEN_TYPE: felt252 = 'Invalid token type';
+    }
+
+    #[abi(per_item)]
+    #[generate_trait]
+    impl CombinedTokenImpl of CombinedTokenTrait {
+        /// @notice Returns token type
+        #[external(v0)]
+        fn get_token_type(self: @ContractState, token_id: u256) -> u8 {
+            self.token_types.read(token_id)
+        }
+
+        /// @notice returns balance of a token for both ERC1155 and ERC721
+        #[external(v0)]
+        fn balance_of(self: @ContractState, account: ContractAddress, token_id: u256) -> u256 {
+            let token_type = self.token_types.read(token_id);
+            assert(token_type == 1 || token_type == 2, Errors::INVALID_TOKEN_TYPE);
+            if token_type == 1 {
+                self.ERC1155_balances.read((token_id, account))
+            } else {
+                self.ERC721_balances.read(account)
+            }
+        }
+
+        /// @notice returns balance of batch for erc1155 tokens
+        #[external(v0)]
+        fn balance_of_batch(
+            self: @ContractState, accounts: Span<ContractAddress>, token_ids: Span<u256>,
+        ) -> Span<u256> {
+            assert(accounts.len() == token_ids.len(), Errors::INVALID_ARRAY_LENGTH);
+
+            let mut batch_balances = array![];
+            let mut index = 0;
+            loop {
+                if index == token_ids.len() {
+                    break;
+                }
+                batch_balances
+                    .append(Self::balance_of(self, *accounts.at(index), *token_ids.at(index)));
+                index += 1;
+            };
+
+            batch_balances.span()
+        }
+
+        /// Change or reaffirm the approved address for an ERC721NFT.
+        ///
+        /// Requirements:
+        ///
+        /// - The caller is either an approved operator or the `token_id` owner.
+        /// - `token_id` exists.
+        ///
+        /// Emits an `Approval` event.
+        #[external(v0)]
+        fn approve(ref self: ContractState, to: ContractAddress, token_id: u256) {
+            self._approve(to, token_id, get_caller_address());
+        }
+
+
+        /// @notice Returns owner of ERC721 token
+        #[external(v0)]
+        fn owner_of(self: @ContractState, token_id: u256) -> ContractAddress {
+            let owner = self.ERC721_owners.read(token_id);
+            assert(owner.is_non_zero(), Errors::INVALID_TOKEN_ID);
+            owner
+        }
+
+        /// Transfers ownership of `value` amount of `token_id` from `from` if `to` is either an
+        /// account or `IERC1155Receiver`.
+        ///
+        /// `data` is additional data, it has no specified format and it is passed to `to`.
+        ///
+        /// WARNING: This function can potentially allow a reentrancy attack when transferring
+        /// tokens to an untrusted contract, when invoking `on_ERC1155_received` on the receiver.
+        /// Ensure to follow the checks-effects-interactions pattern and consider employing
+        /// reentrancy guards when interacting with untrusted contracts.
+        ///
+        /// Requirements:
+        ///
+        /// - Caller is either approved or the `token_id` owner.
+        /// - `from` is not the zero address.
+        /// - `to` is not the zero address.
+        /// - If `to` refers to a non-account contract, it must implement
+        /// `IERC1155Receiver::on_ERC1155_received`
+        ///   and return the required magic value.
+        ///
+        /// Emits a `TransferSingle` event for ERC1155 and `Transfer` event for ERC721
+        #[external(v0)]
+        fn safe_transfer_from(
+            ref self: ContractState,
+            from: ContractAddress,
+            to: ContractAddress,
+            token_id: u256,
+            value: u256,
+            data: Span<felt252>,
+        ) {
+            let token_type = self.token_types.read(token_id);
+
+            if token_type == 1 {
+                // ERC1155 transfer (supports batch transfers)
+                let token_ids = array![token_id].span();
+                let values = array![value].span();
+                Self::safe_batch_transfer_from(ref self, from, to, token_ids, values, data);
+            } else if token_type == 2 {
+                // ERC721 transfer (single transfer, ignores `value`)
+                Self::transfer_from(ref self, from, to, token_id);
+                assert(
+                    _check_on_erc721_received(from, to, token_id, data),
+                    Errors::SAFE_TRANSFER_FAILED,
+                );
+            } else {
+                panic!("Unknown token type");
+            }
+        }
+
+        /// Requirements:
+        ///
+        /// - Caller is either approved or the `token_id` owner.
+        /// - `from` is not the zero address.
+        /// - `to` is not the zero address.
+        /// - `token_ids` and `values` must have the same length.
+        /// - If `to` refers to a non-account contract, it must implement
+        /// `IERC1155Receiver::on_ERC1155_batch_received`
+        ///   and return the acceptance magic value.
+        ///
+        /// Emits either a `TransferSingle` or a `TransferBatch` event, depending on the length of
+        /// the array arguments.
+        #[external(v0)]
+        fn safe_batch_transfer_from(
+            ref self: ContractState,
+            from: starknet::ContractAddress,
+            to: starknet::ContractAddress,
+            token_ids: Span<u256>,
+            values: Span<u256>,
+            data: Span<felt252>,
+        ) {
+            assert(from.is_non_zero(), Errors::INVALID_SENDER);
+            assert(to.is_non_zero(), Errors::INVALID_RECEIVER);
+
+            let operator = get_caller_address();
+            if from != operator {
+                assert(Self::is_approved_for_all(@self, from, operator), Errors::UNAUTHORIZED);
+            }
+
+            self.update_with_acceptance_check(from, to, token_ids, values, data);
+        }
+
+        /// - Caller is either approved or the `token_id` owner.
+        /// - `to` is not the zero address.
+        /// - `from` is not the zero address.
+        /// - `token_id` exists.
+        ///
+        /// Emits a `Transfer` event.
+        #[external(v0)]
+        fn transfer_from(
+            ref self: ContractState, from: ContractAddress, to: ContractAddress, token_id: u256,
+        ) {
+            assert(!to.is_zero(), Errors::INVALID_RECEIVER);
+
+            // Setting an "auth" arguments enables the `_is_authorized` check which verifies that
+            // the token exists (from != 0). Therefore, it is not needed to verify that the return
+            // value is not 0 here.
+            let previous_owner = self.update_erc721(to, token_id, get_caller_address());
+
+            assert(from == previous_owner, Errors::INVALID_SENDER);
+        }
+
+        /// Returns the address approved for `token_id`.
+        ///
+        /// Requirements:
+        ///
+        /// - `token_id` exists.
+        #[external(v0)]
+        fn get_approved(self: @ContractState, token_id: u256) -> ContractAddress {
+            self._require_owned(token_id);
+            self.ERC721_token_approvals.read(token_id)
+        }
+
+        /// Queries if `operator` is an authorized operator for `owner`.
+        #[external(v0)]
+        fn is_approved_for_all(
+            self: @ContractState, owner: ContractAddress, operator: ContractAddress,
+        ) -> bool {
+            self.ERC1155_operator_approvals.read((owner, operator))
+        }
+
+        /// Enables or disables approval for `operator` to manage all of the
+        /// callers assets.
+        ///
+        /// Requirements:
+        /// 
+        /// - `token_type` must be 1 for erc1155 token or 2 for erc721
+        ///
+        /// - `operator` cannot be the caller.
+        ///
+        /// Emits an `ApprovalForAll` event.
+        #[external(v0)]
+        fn set_approval_for_all(
+            ref self: ContractState,
+            owner: ContractAddress,
+            operator: ContractAddress,
+            approved: bool,
+            token_type: u8,
+        ) {
+            assert(token_type == 1 || token_type == 2, Errors::INVALID_TOKEN_TYPE);
+            if token_type == 1 {
+                let owner = get_caller_address();
+                assert(owner != operator, Errors::SELF_APPROVAL);
+
+                self.ERC1155_operator_approvals.write((owner, operator), approved);
+                self.emit(ApprovalForAll { owner, operator, approved });
+            }
+            if token_type == 2 {
+                assert(!operator.is_zero(), Errors::INVALID_OPERATOR);
+                self.ERC721_operator_approvals.write((owner, operator), approved);
+                self.emit(ApprovalForAll { owner, operator, approved });
+            }
+        }
+    }
+
+    #[abi(per_item)]
+    #[generate_trait]
+    pub impl TokenMetadataImpl of TokenMetadataTrait {
+        /// Returns the NFT name.
+        #[external(v0)]
+        fn name(self: @ContractState) -> ByteArray {
+            self.ERC721_name.read()
+        }
+
+        /// Returns the NFT symbol.
+        #[external(v0)]
+        fn symbol(self: @ContractState) -> ByteArray {
+            self.ERC721_symbol.read()
+        }
+
+        /// Returns the Uniform Resource Identifier (URI) for the `token_id` token.
+        /// If the URI is not set, the return value will be an empty ByteArray.
+        ///
+        /// Requirements:
+        ///
+        /// - `token_id` exists.
+        #[external(v0)]
+        fn token_uri(self: @ContractState, token_id: u256) -> ByteArray {
+            self._require_owned(token_id);
+            let base_uri = self._base_uri();
+            if base_uri.len() == 0 {
+                return "";
+            } else {
+                return format!("{}{}", base_uri, token_id);
+            }
+        }
+
+        /// This implementation returns the same URI for *all* token types. It relies
+        /// on the token type ID substitution mechanism defined in the EIP:
+        /// https://eips.ethereum.org/EIPS/eip-1155#metadata.
+        ///
+        /// Clients calling this function must replace the `\{id\}` substring with the
+        /// actual token type ID.
+        #[external(v0)]
+        fn uri(self: @ContractState, token_id: u256) -> ByteArray {
+            self.ERC1155_uri.read()
+        }
+    }
+
+    #[generate_trait]
+    pub impl InternalImpl of InternalTrait {
+        /// Initializes the contract by setting the token name, symbol, and base URI.
+        /// This should only be used inside the contract's constructor.
+        /// @notice One can pass args based on the needed token, empty string `""` can be passed for
+        /// params @notice token_type can only be 1 or 2, pass 0 to initialize both
+        /// ERC1155 and ERC721 tokens @param token_type Determines the token to initialize, 1
+        /// initializes ERC1155 token, 2 initializes ERC721 token, 0 initializes both.
+        fn initializer(
+            ref self: ContractState,
+            name: ByteArray,
+            symbol: ByteArray,
+            erc721_base_uri: ByteArray,
+            erc1155_base_uri: ByteArray,
+            token_type: u8,
+        ) {
+            // Validate token_type
+            assert(
+                token_type <= 2, Errors::INVALID_TOKEN_TYPE,
+            ); // token_type can only be 0, 1, or 2
+
+            // Initialize ERC1155 if token_type is 0 or 1
+            if token_type == 0 || token_type == 1 {
+                self._set_erc1155_base_uri(erc1155_base_uri);
+                self.src5.register_interface(erc1155::IERC1155_ID);
+                self.src5.register_interface(erc1155::IERC1155_METADATA_URI_ID);
+            }
+
+            // Initialize ERC721 if token_type is 0 or 2
+            if token_type == 0 || token_type == 2 {
+                self.ERC721_name.write(name);
+                self.ERC721_symbol.write(symbol);
+                self._set_erc721_base_uri(erc721_base_uri);
+                self.src5.register_interface(interface::IERC721_ID);
+                self.src5.register_interface(interface::IERC721_METADATA_ID);
+            }
+        }
+
+        /// Transfers `token_id` from `from` to `to`.
+        ///
+        /// Internal function without access restriction.
+        ///
+        /// WARNING: This method may lead to the loss of tokens if `to` is not aware of the ERC721
+        /// protocol.
+        ///
+        /// Requirements:
+        ///
+        /// - `to` is not the zero address.
+        /// - `from` is the token owner.
+        /// - `token_id` exists.
+        ///
+        /// Emits a `Transfer` event.
+        fn transfer(
+            ref self: ContractState, from: ContractAddress, to: ContractAddress, token_id: u256,
+        ) {
+            assert(!to.is_zero(), Errors::INVALID_RECEIVER);
+
+            let previous_owner = self.update_erc721(to, token_id, Zero::zero());
+
+            assert(!previous_owner.is_zero(), Errors::INVALID_TOKEN_ID);
+            assert(from == previous_owner, Errors::INVALID_SENDER);
+        }
+
+        /// Transfers ownership of `token_id` from `from` if `to` is either an account or
+        /// `IERC721Receiver`.
+        ///
+        /// `data` is additional data, it has no specified format and it is sent in call to `to`.
+        ///
+        /// WARNING: This method makes an external call to the recipient contract, which can lead to
+        /// reentrancy vulnerabilities.
+        ///
+        /// Requirements:
+        ///
+        /// - `to` cannot be the zero address.
+        /// - `from` must be the token owner.
+        /// - `token_id` exists.
+        /// - `to` is either an account contract or supports the `IERC721Receiver` interface.
+        ///
+        /// Emits a `Transfer` event.
+        fn safe_transfer(
+            ref self: ContractState,
+            from: ContractAddress,
+            to: ContractAddress,
+            token_id: u256,
+            data: Span<felt252>,
+        ) {
+            self.transfer(from, to, token_id);
+            assert(
+                _check_on_erc721_received(from, to, token_id, data), Errors::SAFE_TRANSFER_FAILED,
+            );
+        }
+
+        /// Returns whether `token_id` exists.
+        fn exists(self: @ContractState, token_id: u256) -> bool {
+            !self._owner_of(token_id).is_zero()
+        }
+
+        fn _approve(
+            ref self: ContractState, to: ContractAddress, token_id: u256, auth: ContractAddress,
+        ) {
+            self._approve_with_optional_event(to, token_id, auth, true);
+        }
+
+        /// ERC721 only
+        /// Mints `token_id` and transfers it to `to`.
+        /// Internal function without access restriction.
+        ///
+        /// WARNING: This method may lead to the loss of tokens if `to` is not aware of the ERC721
+        /// protocol.
+        ///
+        /// Requirements:
+        ///
+        /// - `to` is not the zero address.
+        /// - `token_id` does not exist.
+        ///
+        /// Emits a `Transfer` event.
+        fn mint(ref self: ContractState, to: ContractAddress, token_id: u256) {
+            assert(!to.is_zero(), Errors::INVALID_RECEIVER);
+
+            let previous_owner = self.update_erc721(to, token_id, Zero::zero());
+            self.token_types.write(token_id, 2);
+            assert(previous_owner.is_zero(), Errors::ALREADY_MINTED);
+        }
+
+        /// ERC721 only
+        /// Mints `token_id` if `to` is either an account or `IERC721Receiver`.
+        ///
+        /// `data` is additional data, it has no specified format and it is sent in call to `to`.
+        ///
+        /// WARNING: This method makes an external call to the recipient contract, which can lead to
+        /// reentrancy vulnerabilities.
+        ///
+        /// Requirements:
+        ///
+        /// - `token_id` does not exist.
+        /// - `to` is either an account contract or supports the `IERC721Receiver` interface.
+        ///
+        /// Emits a `Transfer` event.
+        fn safe_mint(
+            ref self: ContractState, to: ContractAddress, token_id: u256, data: Span<felt252>,
+        ) {
+            self.mint(to, token_id);
+            self.token_types.write(token_id, 2);
+
+            assert(
+                _check_on_erc721_received(Zero::zero(), to, token_id, data),
+                Errors::SAFE_MINT_FAILED,
+            );
+        }
+
+        /// ERC1155 only
+        /// Creates a `value` amount of tokens of type `token_id`, and assigns them to `to`.
+        ///
+        /// Requirements:
+        ///
+        /// - `to` cannot be the zero address.
+        /// - If `to` refers to a smart contract, it must implement
+        /// `IERC1155Receiver::on_ERC1155_received`
+        /// and return the acceptance magic value.
+        ///
+        /// Emits a `TransferSingle` event.
+        fn mint_with_acceptance_check(
+            ref self: ContractState,
+            to: ContractAddress,
+            token_id: u256,
+            value: u256,
+            data: Span<felt252>,
+        ) {
+            assert(to.is_non_zero(), Errors::INVALID_RECEIVER);
+
+            let token_ids = array![token_id].span();
+            let values = array![value].span();
+            self.update_with_acceptance_check(Zero::zero(), to, token_ids, values, data);
+            self.token_types.write(token_id, 1);
+        }
+
+        /// Batched version of `mint_with_acceptance_check`.
+        ///
+        /// Requirements:
+        ///
+        /// - `to` cannot be the zero address.
+        /// - `token_ids` and `values` must have the same length.
+        /// - If `to` refers to a smart contract, it must implement
+        /// `IERC1155Receiver::on_ERC1155_batch_received`
+        /// and return the acceptance magic value.
+        ///
+        /// Emits a `TransferBatch` event.
+        fn batch_mint_with_acceptance_check(
+            ref self: ContractState,
+            to: ContractAddress,
+            token_ids: Span<u256>,
+            values: Span<u256>,
+            data: Span<felt252>,
+        ) {
+            assert(to.is_non_zero(), Errors::INVALID_RECEIVER);
+            self.update_with_acceptance_check(Zero::zero(), to, token_ids, values, data);
+
+            let mut index = 0;
+            loop {
+                if index == token_ids.len() { break; }
+                let token_id = *token_ids.at(index);
+                self.token_types.write(token_id, 1);
+                index += 1;
+            }
+        }
+
+        /// Destroys a `value` amount of tokens of type `token_id` from `from`.
+        ///
+        /// Requirements:
+        ///
+        /// - `from` cannot be the zero address.
+        /// - `from` must have at least `value` amount of tokens of type `token_id`.
+        ///
+        /// Emits a `TransferSingle` event.
+        fn burn(
+            ref self: ContractState,
+            from: ContractAddress,
+            token_id: u256,
+            value: u256,
+        ) {
+            let token_type = self.token_types.read(token_id);
+            assert(token_type <= 2, Errors::INVALID_TOKEN_TYPE);
+            // burn ERC1155
+            if token_type == 1 {
+                assert(from.is_non_zero(), Errors::INVALID_SENDER);
+                let token_ids = array![token_id].span();
+                let values = array![value].span();
+                self.update_erc1155(from, Zero::zero(), token_ids, values);
+            }
+            // burn ERC721
+            if token_type == 2 {
+                let previous_owner = self.update_erc721(Zero::zero(), token_id, Zero::zero());
+                assert(!previous_owner.is_zero(), Errors::INVALID_TOKEN_ID);
+            }
+        }
+
+        /// Batched version of `burn`.
+        ///
+        /// Requirements:
+        ///
+        /// - `from` cannot be the zero address.
+        /// - `from` must have at least `value` amount of tokens of type `token_id`.
+        /// - `token_ids` and `values` must have the same length.
+        ///
+        /// Emits a `TransferBatch` event.
+        fn batch_burn(
+            ref self: ContractState,
+            from: ContractAddress,
+            token_ids: Span<u256>,
+            values: Span<u256>,
+        ) {
+            assert(from.is_non_zero(), Errors::INVALID_SENDER);
+            self.update_erc1155(from, Zero::zero(), token_ids, values);
+        }
+
+
+        /// Version of `update` that performs the token acceptance check by calling
+        /// `IERC1155Receiver::onERC1155Received` or `IERC1155Receiver::onERC1155BatchReceived` if
+        /// the receiver is not recognized as an account.
+        ///
+        /// Requirements:
+        ///
+        /// - `to` is either an account contract or supports the `IERC1155Receiver` interface.
+        /// - `token_ids` and `values` must have the same length.
+        ///
+        /// Emits a `TransferSingle` event if the arrays contain one element, and `TransferBatch`
+        /// otherwise.
+        fn update_with_acceptance_check(
+            ref self: ContractState,
+            from: ContractAddress,
+            to: ContractAddress,
+            token_ids: Span<u256>,
+            values: Span<u256>,
+            data: Span<felt252>,
+        ) {
+            self.update_erc1155(from, to, token_ids, values);
+            let accepted = if token_ids.len() == 1 {
+                _check_on_ERC1155_received(from, to, *token_ids.at(0), *values.at(0), data)
+            } else {
+                _check_on_ERC1155_batch_received(from, to, token_ids, values, data)
+            };
+            assert(accepted, Errors::SAFE_TRANSFER_FAILED);
+        }
+
+
+        /// Transfers a `value` amount of tokens of type `id` from `from` to `to`.
+        /// Will mint (or burn) if `from` (or `to`) is the zero address.
+        ///
+        /// Requirements:
+        ///
+        /// - `token_ids` and `values` must have the same length.
+        ///
+        /// Emits a `TransferSingle` event if the arrays contain one element, and `TransferBatch`
+        /// otherwise.
+        ///
+        /// NOTE: This function can be extended using the `ERC1155HooksTrait`, to add
+        /// functionality before and/or after the transfer, mint, or burn.
+        ///
+        /// NOTE: The ERC1155 acceptance check is not performed in this function.
+        /// See `update_with_acceptance_check` instead.
+        fn update_erc1155(
+            ref self: ContractState,
+            from: ContractAddress,
+            to: ContractAddress,
+            token_ids: Span<u256>,
+            values: Span<u256>,
+        ) {
+            assert(token_ids.len() == values.len(), Errors::INVALID_ARRAY_LENGTH);
+
+            let mut index = 0;
+            loop {
+                if index == token_ids.len() {
+                    break;
+                }
+                let token_id = *token_ids.at(index);
+                let value = *values.at(index);
+                if from.is_non_zero() {
+                    let from_balance = self.ERC1155_balances.read((token_id, from));
+                    assert(from_balance >= value, Errors::INSUFFICIENT_BALANCE);
+                    self.ERC1155_balances.write((token_id, from), from_balance - value);
+                }
+                if to.is_non_zero() {
+                    let to_balance = self.ERC1155_balances.read((token_id, to));
+                    self.ERC1155_balances.write((token_id, to), to_balance + value);
+                }
+                index += 1;
+            };
+            let operator = get_caller_address();
+            if token_ids.len() == 1 {
+                self
+                    .emit(
+                        TransferSingle {
+                            operator, from, to, id: *token_ids.at(0), value: *values.at(0),
+                        },
+                    );
+            } else {
+                self.emit(TransferBatch { operator, from, to, ids: token_ids, values });
+            }
+        }
+
+        fn update_erc721(
+            ref self: ContractState, to: ContractAddress, token_id: u256, auth: ContractAddress,
+        ) -> ContractAddress {
+            let from = self._owner_of(token_id);
+
+            // Perform (optional) operator check
+            if !auth.is_zero() {
+                self._check_authorized(from, auth, token_id);
+            }
+            if !from.is_zero() {
+                let zero_address = Zero::zero();
+                self._approve_with_optional_event(zero_address, token_id, zero_address, false);
+
+                self.ERC721_balances.write(from, self.ERC721_balances.read(from) - 1);
+            }
+            if !to.is_zero() {
+                self.ERC721_balances.write(to, self.ERC721_balances.read(to) + 1);
+            }
+
+            self.ERC721_owners.write(token_id, to);
+            self.emit(Transfer { from, to, token_id });
+
+            from
+        }
+
+        /// Returns the owner address of `token_id`.
+        fn _owner_of(self: @ContractState, token_id: u256) -> ContractAddress {
+            self.ERC721_owners.read(token_id)
+        }
+
+        /// Variant of `_approve` with an optional flag to enable or disable the `Approval` event.
+        /// The event is not emitted in the context of transfers.
+        ///
+        /// WARNING: If `auth` is zero and `emit_event` is false, this function will not check that
+        /// the token exists.
+        ///
+        /// Requirements:
+        ///
+        /// - If `auth` is non-zero, it must be either the owner of the token or approved to
+        /// operate on all of its tokens.
+        ///
+        /// May emit an `Approval` event.
+        fn _approve_with_optional_event(
+            ref self: ContractState,
+            to: ContractAddress,
+            token_id: u256,
+            auth: ContractAddress,
+            emit_event: bool,
+        ) {
+            if emit_event || !auth.is_zero() {
+                let owner = self._require_owned(token_id);
+
+                if !auth.is_zero() && owner != auth {
+                    let is_approved_for_all = CombinedTokenImpl::is_approved_for_all(
+                        @self, owner, auth,
+                    );
+                    assert(is_approved_for_all, Errors::UNAUTHORIZED);
+                }
+
+                if emit_event {
+                    self.emit(Approval { owner, approved: to, token_id });
+                }
+            }
+
+            self.ERC721_token_approvals.write(token_id, to);
+        }
+
+        /// Returns the owner address of `token_id`.
+        ///
+        /// Requirements:
+        ///
+        /// - `token_id` exists.
+        fn _require_owned(self: @ContractState, token_id: u256) -> ContractAddress {
+            let owner = self._owner_of(token_id);
+            assert(!owner.is_zero(), Errors::INVALID_TOKEN_ID);
+            owner
+        }
+
+        /// Sets the erc721 base URI.
+        fn _set_erc721_base_uri(ref self: ContractState, base_uri: ByteArray) {
+            self.ERC721_base_uri.write(base_uri);
+        }
+
+        /// Sets a new URI for all token types, by relying on the token type ID
+        /// substitution mechanism defined in the ERC1155 standard.
+        /// See https://eips.ethereum.org/EIPS/eip-1155#metadata.
+        ///
+        /// By this mechanism, any occurrence of the `\{id\}` substring in either the
+        /// URI or any of the values in the JSON file at said URI will be replaced by
+        /// clients with the token type ID.
+        ///
+        /// For example, the `https://token-cdn-domain/\{id\}.json` URI would be
+        /// interpreted by clients as
+        /// `https://token-cdn-domain/000000000000000000000000000000000000000000000000000000000004cce0.json`
+        /// for token type ID 0x4cce0.
+        ///
+        /// Because these URIs cannot be meaningfully represented by the `URI` event,
+        /// this function emits no events.
+        fn _set_erc1155_base_uri(ref self: ContractState, base_uri: ByteArray) {
+            self.ERC1155_uri.write(base_uri);
+        }
+
+        /// Base URI for computing `token_uri`.
+        ///
+        /// If set, the resulting URI for each token will be the concatenation of the base URI and
+        /// the token ID.
+        /// Returns an empty `ByteArray` if not set.
+        fn _base_uri(self: @ContractState) -> ByteArray {
+            self.ERC721_base_uri.read()
+        }
+
+
+        /// Returns whether `spender` is allowed to manage `owner`'s tokens, or `token_id` in
+        /// particular (ignoring whether it is owned by `owner`).
+        ///
+        /// WARNING: This function assumes that `owner` is the actual owner of `token_id` and does
+        /// not verify this assumption.
+        fn _is_authorized(
+            self: @ContractState, owner: ContractAddress, spender: ContractAddress, token_id: u256,
+        ) -> bool {
+            let is_approved_for_all = CombinedTokenImpl::is_approved_for_all(self, owner, spender);
+
+            !spender.is_zero()
+                && (owner == spender
+                    || is_approved_for_all
+                    || spender == CombinedTokenImpl::get_approved(self, token_id))
+        }
+
+        /// Checks if `spender` can operate on `token_id`, assuming the provided `owner` is the
+        /// actual owner.
+        ///
+        /// Requirements:
+        ///
+        /// - `owner` cannot be the zero address.
+        /// - `spender` cannot be the zero address.
+        /// - `spender` must be the owner of `token_id` or be approved to operate on it.
+        ///
+        /// WARNING: This function assumes that `owner` is the actual owner of `token_id` and does
+        /// not verify this assumption.
+        fn _check_authorized(
+            ref self: ContractState,
+            owner: ContractAddress,
+            spender: ContractAddress,
+            token_id: u256,
+        ) {
+            // Non-existent token
+            assert(!owner.is_zero(), Errors::INVALID_TOKEN_ID);
+            assert(self._is_authorized(owner, spender, token_id), Errors::UNAUTHORIZED);
+        }
+    }
+
+    ///////////////////  END OF INTERNAL IMPL   ///////////////////////
+
+    /// Checks if `to` either is an account contract or has registered support
+    /// for the `IERC721Receiver` interface through SRC5.
+    fn _check_on_erc721_received(
+        from: ContractAddress, to: ContractAddress, token_id: u256, data: Span<felt252>,
+    ) -> bool {
+        let src5_dispatcher = ISRC5Dispatcher { contract_address: to };
+
+        if src5_dispatcher.supports_interface(interface::IERC721_RECEIVER_ID) {
+            IERC721ReceiverDispatcher { contract_address: to }
+                .on_erc721_received(
+                    get_caller_address(), from, token_id, data,
+                ) == interface::IERC721_RECEIVER_ID
+        } else {
+            src5_dispatcher.supports_interface(openzeppelin_account::interface::ISRC6_ID)
+        }
+    }
+
+    /// Checks if `to` accepts the token by implementing `IERC1155Receiver`
+    /// or if it's an account contract (supporting ISRC6).
+    fn _check_on_ERC1155_received(
+        from: ContractAddress,
+        to: ContractAddress,
+        token_id: u256,
+        value: u256,
+        data: Span<felt252>,
+    ) -> bool {
+        let src5_dispatcher = ISRC5Dispatcher { contract_address: to };
+
+        if src5_dispatcher.supports_interface(erc1155::IERC1155_RECEIVER_ID) {
+            IERC1155ReceiverDispatcher { contract_address: to }
+                .on_erc1155_received(
+                    get_caller_address(), from, token_id, value, data,
+                ) == erc1155::IERC1155_RECEIVER_ID
+        } else {
+            src5_dispatcher.supports_interface(ISRC6_ID)
+        }
+    }
+
+    /// Checks if `to` accepts the token by implementing `IERC1155Receiver`
+    /// or if it's an account contract (supporting ISRC6).
+    fn _check_on_ERC1155_batch_received(
+        from: ContractAddress,
+        to: ContractAddress,
+        token_ids: Span<u256>,
+        values: Span<u256>,
+        data: Span<felt252>,
+    ) -> bool {
+        let src5_dispatcher = ISRC5Dispatcher { contract_address: to };
+
+        if src5_dispatcher.supports_interface(erc1155::IERC1155_RECEIVER_ID) {
+            IERC1155ReceiverDispatcher { contract_address: to }
+                .on_erc1155_batch_received(
+                    get_caller_address(), from, token_ids, values, data,
+                ) == erc1155::IERC1155_RECEIVER_ID
+        } else {
+            src5_dispatcher.supports_interface(ISRC6_ID)
+        }
+    }
 }
+

--- a/docs/erc721_erc1155_research.md
+++ b/docs/erc721_erc1155_research.md
@@ -1,0 +1,84 @@
+# ERC721 and ERC1155 Compatibility Research
+
+## Interfaces
+
+### ERC721
+ERC721 defines unique interface identifiers that must be present to ensure compatibility with the standard. These identifiers help contracts verify the implementation of ERC721 functionalities.
+
+- **`IERC721_ID`**: Identifies the ERC721 interface.
+- **`IERC721_METADATA_ID`**: Identifies the ERC721 metadata extension, which includes `name`, `symbol`, and `tokenURI`.
+- **`IERC721_RECEIVER_ID`**: Ensures a contract can safely receive ERC721 tokens, preventing accidental token loss.
+
+### ERC1155
+Similar to ERC721, ERC1155 has unique interface identifiers that define its structure and ensure compliance with the standard.
+
+- **`IERC1155_ID`**: Identifies the ERC1155 interface.
+- **`IERC1155_METADATA_URI_ID`**: Identifies the metadata extension, using a URI-based metadata structure.
+- **`IERC1155_RECEIVER_ID`**: Ensures a contract can safely receive ERC1155 tokens.
+
+## Compatibility Issues
+
+### Interface Differences
+Both ERC721 and ERC1155 require unique interface identifiers to ensure compatibility. Any contract aiming to support both must include all necessary identifiers.
+
+### Token Uniqueness
+- **ERC721**: Each token has a unique `token_id` and exists as a separate entity.
+- **ERC1155**: Multiple tokens can share the same `token_id` but have different balances.
+- **Issue**: Applications designed for ERC721 may not function properly with ERC1155 due to their different handling of token uniqueness.
+
+### Token Transfer Methods
+- **ERC721**: Uses `safe_transfer_from()`, transferring one token at a time.
+- **ERC1155**: Uses both `safe_transfer_from()` and `safe_batch_transfer_from()`, enabling batch transfers.
+- **Issue**: Applications built for ERC721 may not support batch transfers, causing compatibility issues with ERC1155.
+
+### Receiving Tokens
+- **ERC721**: Uses `on_erc721_received()` for receiving tokens.
+- **ERC1155**: Uses `on_erc1155_received()` and `on_erc1155_batch_received()`.
+- **Issue**: A contract designed to accept ERC721 tokens will reject ERC1155 tokens and vice versa.
+
+### Metadata URI Differences
+- **ERC721**: Uses `token_uri(token_id: u256)`, returning a unique metadata URI for each token.
+- **ERC1155**: Uses `uri(u256 token_id)`, returning a templated URI where the `token_id` is dynamically inserted.
+  - Example:
+    - ERC1155: `"https://uri.com/metadata/{id}.json"`
+    - ERC721: `"https://uri.com/metadata/1.json"`
+- **Issue**: Systems built for ERC721 may not dynamically insert `token_id` values, causing incompatibility with ERC1155.
+
+### Ownership and Balance Tracking
+- **ERC721**: Maps `token_id` to an `owner` address.
+- **ERC1155**: Uses a 2D mapping of `owner` and `token_id` to determine balances.
+- **Issue**: The different methods for tracking ownership and balances complicate compatibility between the two standards.
+
+### Approval Mechanism
+- **ERC721**:
+  - `approve()`: Grants approval for a specific token.
+  - `set_approval_for_all()`: Grants approval for an operator to manage all user tokens.
+- **ERC1155**:
+  - Only supports `set_approval_for_all()`, which applies to all tokens owned by the caller.
+- **Issue**: ERC1155 lacks per-token approvals, which may cause issues for applications expecting ERC721’s granular approval system.
+
+## Key Differences Between ERC721 and ERC1155
+
+| Feature                  | ERC721                                      |ERC1155    
+|--------------------------|---------------------------------------------|---------------------------------------------|
+| **Type of Token**        | Non-fungible (unique assets only)           | Both fungible and non-fungible tokens       |
+| **Storage**              | Requires separate storage for each token    | Uses a single mapping for all token types   |
+| **Transfers**            | One-by-one transfer of individual tokens    | Batch transfer of multiple tokens at once   |
+| **Gas Efficiency**       | Less efficient, especially for large amounts| More efficient due to batch transfer support|
+| **Metadata**             | Metadata per token (stored off-chain usually)| Can have metadata per token but            |
+|                          |                                              | more flexible with batch handling          |
+
+| **Receiver Function**    | `onERC721Received`                          | `onERC1155Received` and                     |
+|                          |                                             | `onERC1155BatchReceived`                    |
+
+| **Use Case**             | Ideal for collectibles, art, and other use  | Suitable for games, in-game                 |
+|                          | cases                                       | assets, digital art, and fungible           |
+|                          |                                             | tokens                                      |
+
+## Implementation Study
+
+A single contract that integrate both ERC1155 and ERC721 token standards can be tricky and complex. A few ways this may be achieved include:
+- Setting a token type with unique identification number that can be dynamically passed to each contract call. The function interactions and the value to be returned (if any) depend on the token type detected.
+
+(not conclusive yet)...
+

--- a/docs/erc721_erc1155_research.md
+++ b/docs/erc721_erc1155_research.md
@@ -75,7 +75,7 @@ Both ERC721 and ERC1155 require unique interface identifiers to ensure compatibi
 |                          | cases                                       | assets, digital art, and fungible           |
 |                          |                                             | tokens                                      |
 
-## Implementation Study
+## Technical Architecture and Implementation Recommendations
 
 A single contract that integrate both ERC1155 and ERC721 token standards can be tricky and complex. A few ways this may be achieved include:
 - Setting a token type with unique identification number that can be dynamically passed to each contract call. The function interactions and the value to be returned (if any) depend on the token type detected.
@@ -190,3 +190,23 @@ The contract uses a robust error-handling mechanism to ensure safe and predictab
 - The contract verifies that recipient contracts implement the required receiver interfaces (`IERC721Receiver` or `IERC1155Receiver`) before proceeding with transfers. If the checks fail, the transfer is reverted with an appropriate error (e.g., `SAFE_TRANSFER_FAILED`).
 
 ---
+
+### Feasibility Report
+The combined `ERC721` and `ERC1155` token standard is feasible and offers significant advantages in terms of flexibility, gas efficiency, and interoperability. It is suited for projects that seek to support both non-fungible and semi-fungible tokens.
+
+However, for the limited time I had to brainstorm and implement this, the best idea I could think of was to use existing implementations for the two token standards; where possible same function can work for the two token standards, but in other cases the functions are unique for each standard.
+
+Using the existing implementations made sense for a few reasons, the most important of which was interoperability with existing tools, wallets, marketplaces and other NFT infrastructure. E.g, 
+   - The contract adheres to both ERC721 and ERC1155 interfaces, ensuring compatibility with existing tools, wallets, and marketplaces as I already mentioned.
+   - It also implements the `SRC5` interface for interface support checks, ensuring robust interoperability.
+
+   - The contract ensures compatibility with receiver contracts by implementing checks for `IERC721Receiver` and `IERC1155Receiver`.
+   - Fallback to account contracts (supporting `ISRC6`) is provided for enhanced flexibility.
+   - Even though the storage is structured to manage the two token standards at once, the variables are named in accordance to the official naming styles used for the both token standards to ensure compatibility.
+   - The function signatures are compatible with the conventional function signatures for the both standards.
+
+## **Conclusion**
+
+The combined ERC1155 and ERC721 token standard represents a significant step forward in token standardization, offering a flexible and unified solution for managing both non-fungible and semi-fungible tokens within a single contract. By merging the strengths of ERC721 and ERC1155, this research demonstrates the feasibility of a hybrid approach that reduces deployment complexity, optimizes gas costs, and enhances interoperability.
+
+If more time and resources are dedicated to advancing this research, it has the potential to give rise to a **new, unique token standard**. This standard would introduce its own `SRC5 Interface ID`, complete with robust implementations that define how it interacts with the broader token ecosystem. Such a standard could revolutionize token management by offering developers a versatile and efficient framework for creating and managing diverse token types, paving the way for innovative use cases and greater adoption across the blockchain community.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "ST-Backend",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
# Pull Request for STARKLA - Close Issue #3 

- Analyzed interface differences, including unique identifiers for ERC721 (IERC721_ID, IERC721_METADATA_ID) and ERC1155 (IERC1155_ID, IERC1155_METADATA_URI_ID).
- Identified key compatibility issues, such as token uniqueness, transfer methods, metadata URI structures, and ownership tracking.
- Examined approval mechanisms and receiving token logic, highlighting challenges in merging both standards.
- Compared ERC721 and ERC1155 in terms of storage, gas efficiency, and batch processing capabilities.


